### PR TITLE
Remove gadget name link target to metawiki from table output

### DIFF
--- a/default_gadgets.py
+++ b/default_gadgets.py
@@ -36,7 +36,7 @@ def family_default_gadgets(family='wikipedia'):
 					gadgets_dict[gadget].append( gadget_item )
 		except NoPage:
 			continue
-	output = [('| [[Gadgets/%s|%s]] || %s || %i'%(k, k, ', '.join(v), len(v)), len(v)) for k,v in gadgets_dict.items()]
+	output = [('| %s || %s || %i'%(k, ', '.join(v), len(v)), len(v)) for k,v in gadgets_dict.items()]
 	output.sort(key=lambda x:-x[1])  # sort by popularity
 	output = """Default gadgets in project %s.
 {| class="wikitable sortable plainlinks"

--- a/gadgets_popular.py
+++ b/gadgets_popular.py
@@ -88,7 +88,7 @@ for family, gadgets in familyGadgets.iteritems():
     gadgetsDetails = [(gadgetName,', '.join([u'%s (%s)'%(link,str(count)) for link, count in langData]), sum([count for link,count in langData])) for gadgetName, langData in gadgets.iteritems()]
     gadgetsDetails.sort(key=lambda x:x[2], reverse=True)
 	
-    gadgetsInfo = [u'| [[Gadgets/%s]] || %s || %i'%(gadgetName, langData, totalCount) for gadgetName, langData, totalCount in gadgetsDetails]
+    gadgetsInfo = [u'| %s || %s || %i'%(gadgetName, langData, totalCount) for gadgetName, langData, totalCount in gadgetsDetails]
     family_report = report_family_template % (family, datetime.datetime.now().strftime('%B %Y'), '\n|-\n'.join(gadgetsInfo))
     meta_wiki = pywikibot.getSite('meta', 'meta')
     meta_page = pywikibot.Page(meta_wiki, 'Gadgets/%s'%(family))


### PR DESCRIPTION
Linking each gadget to its metawiki page (existing or not) could make
users think that metawiki hosts the canonical source of that gadget's
code or wonder why in some cases the link is red when that gadget is
not available on metawiki.
There is no good way to identify the canonical source location of a
gadget, hence remove the metawiki link target from the first column.
Users can still investigate by using the links in the second column.

See https://phabricator.wikimedia.org/T251362 for discussion.